### PR TITLE
isPlainObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2025-07-24
+
+### Added
+
+- A type predicate (as opposed to a type guard) that tests whether a value is a plain JS
+object. It's only true in 2 cases:
+  - If the object was created with a literal.
+  - If the object was created with the `Object` constructor (`new Object()`).
+
+### Fixed
+
+- The return signature of `isObject`. Previously, the type guard stated `value is object`
+as its return type, but this is incorrect. `typeof null` returns `"object"`, but the
+typescript `object` type [does not include null values](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type).
+Therefore, the real type that the type guard is checking against is `object | null`, and
+not strictly `object`.
+
 ## [0.11.0] - 2025-07-23
 
 ### Added
@@ -139,6 +156,10 @@ that does the same, but probably better.
   - `isNumber`
   - `isFunction`
 
+[0.12.0]: https://github.com/infra-blocks/ts-types/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/infra-blocks/ts-types/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/infra-blocks/ts-types/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/infra-blocks/ts-types/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/infra-blocks/ts-types/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/infra-blocks/ts-types/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/infra-blocks/ts-types/compare/v0.5.5...v0.6.0

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -86,7 +86,7 @@ export function isNull(value: unknown): value is null {
  *
  * @see https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
  */
-export function isObject(value: unknown): value is object {
+export function isObject(value: unknown): value is object | null {
   return typeof value === "object";
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./func.js";
 export * from "./guard.js";
 export * from "./events.js";
+export * from "./predicates.js";
 
 /**
  * Convenience type to represent environment variables.

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -1,0 +1,15 @@
+/**
+ * A type predicate to determine if a value is a plain object.
+ *
+ * A plain object is created either with the object literal syntax or with the Object constructor.
+ * Any other type of object will not satisfy this predicate.
+ *
+ * @param value - The value to test.
+ *
+ * @returns Whether or not the value is a plain object.
+ */
+export function isPlainObject(value: unknown): boolean {
+  return (
+    typeof value === "object" && value !== null && value.constructor === Object
+  );
+}

--- a/test/unit/predicates.spec.ts
+++ b/test/unit/predicates.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from "@infra-blocks/test";
+import { isPlainObject } from "../../src/predicates.js";
+
+describe("predicates", () => {
+  describe(isPlainObject.name, function () {
+    it("should return false for undefined", function () {
+      expect(isPlainObject(undefined)).to.be.false;
+    });
+    it("should return false for null", function () {
+      expect(isPlainObject(null)).to.be.false;
+    });
+    it("should return false for a number", function () {
+      expect(isPlainObject(42)).to.be.false;
+    });
+    it("should return false for a bigint", function () {
+      expect(isPlainObject(42n)).to.be.false;
+    });
+    it("should return false for a string", function () {
+      expect(isPlainObject("test")).to.be.false;
+    });
+    it("should return false for a boolean", function () {
+      expect(isPlainObject(true)).to.be.false;
+    });
+    it("should return false for a symbol", function () {
+      expect(isPlainObject(Symbol("test"))).to.be.false;
+    });
+    it("should return false for an array", function () {
+      expect(isPlainObject([1, 2, 3])).to.be.false;
+    });
+    it("should return false for a custom class instance", function () {
+      class CustomClass {}
+      expect(isPlainObject(new CustomClass())).to.be.false;
+    });
+    it("should return true for an object literal", function () {
+      expect(isPlainObject({})).to.be.true;
+    });
+    it("should return true for an object created with Object constructor", function () {
+      expect(isPlainObject(new Object())).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
- Added a predicate to test if an object is a plain javascript object.
- Fixed the guard type of `isObject` that was coercing to an object
when it could be null.
